### PR TITLE
Add Bean Lifecycle Hooks (@PreDestroy)

### DIFF
--- a/src/main/java/io/github/abolpv/lightdi/annotation/PreDestroy.java
+++ b/src/main/java/io/github/abolpv/lightdi/annotation/PreDestroy.java
@@ -1,0 +1,46 @@
+package io.github.abolpv.lightdi.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method to be executed when the container is shutting down.
+ * The annotated method must have no parameters and return void.
+ * This is typically used for cleanup operations like closing connections,
+ * releasing resources, or flushing caches.
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * {@literal @}Injectable
+ * {@literal @}Singleton
+ * public class DatabaseConnection {
+ *     private Connection connection;
+ *
+ *     {@literal @}PostConstruct
+ *     public void connect() {
+ *         connection = DriverManager.getConnection(url);
+ *     }
+ *
+ *     {@literal @}PreDestroy
+ *     public void disconnect() {
+ *         // Called when container.shutdown() is invoked
+ *         if (connection != null) {
+ *             connection.close();
+ *         }
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>Note: @PreDestroy methods are called in reverse order of bean creation,
+ * ensuring that dependencies are still available during cleanup.</p>
+ *
+ * @author Abolfazl Azizi
+ * @since 1.0.0
+ * @see PostConstruct
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreDestroy {
+}

--- a/src/main/java/io/github/abolpv/lightdi/util/ReflectionUtils.java
+++ b/src/main/java/io/github/abolpv/lightdi/util/ReflectionUtils.java
@@ -3,6 +3,7 @@ package io.github.abolpv.lightdi.util;
 import io.github.abolpv.lightdi.annotation.Inject;
 import io.github.abolpv.lightdi.annotation.Named;
 import io.github.abolpv.lightdi.annotation.PostConstruct;
+import io.github.abolpv.lightdi.annotation.PreDestroy;
 import io.github.abolpv.lightdi.exception.ContainerException;
 
 import java.lang.annotation.Annotation;
@@ -155,7 +156,41 @@ public final class ReflectionUtils {
             );
         }
     }
-    
+
+    /**
+     * Finds the method annotated with @PreDestroy.
+     *
+     * @param clazz the class to inspect
+     * @return optional containing the pre-destroy method if found
+     */
+    public static Optional<Method> findPreDestroyMethod(Class<?> clazz) {
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            for (Method method : current.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(PreDestroy.class)) {
+                    validatePreDestroyMethod(method);
+                    method.setAccessible(true);
+                    return Optional.of(method);
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return Optional.empty();
+    }
+
+    private static void validatePreDestroyMethod(Method method) {
+        if (method.getParameterCount() != 0) {
+            throw new ContainerException(
+                "@PreDestroy method must have no parameters: " + method
+            );
+        }
+        if (method.getReturnType() != void.class) {
+            throw new ContainerException(
+                "@PreDestroy method must return void: " + method
+            );
+        }
+    }
+
     /**
      * Gets the @Named qualifier value from an annotation array.
      *


### PR DESCRIPTION
## Summary
Implements `@PreDestroy` lifecycle hook for cleanup operations when the container is shut down.

Closes #3

## Changes
- Created `@PreDestroy` annotation in `io.github.abolpv.lightdi.annotation`
- Added `findPreDestroyMethod()` in `ReflectionUtils` to discover cleanup methods
- Added `singletonInstances` list in `Container` to track bean creation order
- Implemented `shutdown()` method that invokes `@PreDestroy` in reverse creation order
- Added `shutdownInProgress` flag to prevent duplicate shutdown calls

## Example Usage
```java
@Injectable
@Singleton
public class DatabaseConnection {
    private Connection conn;
    
    @PostConstruct
    public void init() {
        conn = DriverManager.getConnection(url);
    }
    
    @PreDestroy
    public void cleanup() {
        conn.close();  // Called when container.shutdown() is invoked
    }
}

// Application shutdown
container.shutdown();  // Invokes @PreDestroy methods in reverse order
```

## Test Plan
- [x] `@PreDestroy` methods are called during `shutdown()`
- [x] Cleanup happens in reverse creation order (LIFO)
- [x] Only singleton beans trigger `@PreDestroy`
- [x] Multiple `shutdown()` calls are idempotent
- [x] Exceptions in one `@PreDestroy` don't prevent others from running