### PR TITLE
Add Conditional Bean Registration (@ConditionalOn)

### DIFF
--- a/src/main/java/io/github/abolpv/lightdi/annotation/ConditionalOnBean.java
+++ b/src/main/java/io/github/abolpv/lightdi/annotation/ConditionalOnBean.java
@@ -1,0 +1,36 @@
+package io.github.abolpv.lightdi.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Conditionally registers a bean only if another bean of the specified type exists.
+ * This is useful for optional features that depend on other beans being present.
+ *
+ * <p>Usage example:</p>
+ * <pre>
+ * {@literal @}Injectable
+ * {@literal @}ConditionalOnBean(DataSource.class)
+ * public class JdbcUserRepository implements UserRepository { }
+ * </pre>
+ *
+ * <p>The condition is evaluated at registration time. If the specified bean type
+ * is not registered when this bean is being registered, this bean will be skipped.</p>
+ *
+ * @author Abolfazl Azizi
+ * @since 1.0.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConditionalOnBean {
+
+    /**
+     * The bean type(s) that must be present for this bean to be registered.
+     * If multiple types are specified, ALL must be present.
+     *
+     * @return the bean type(s) to check
+     */
+    Class<?>[] value();
+}

--- a/src/main/java/io/github/abolpv/lightdi/annotation/ConditionalOnMissingBean.java
+++ b/src/main/java/io/github/abolpv/lightdi/annotation/ConditionalOnMissingBean.java
@@ -1,0 +1,42 @@
+package io.github.abolpv.lightdi.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Conditionally registers a bean only if no other bean of the specified type exists.
+ * This is useful for providing fallback/default implementations.
+ *
+ * <p>Usage example:</p>
+ * <pre>
+ * // Primary implementation (registered if cache.enabled=true)
+ * {@literal @}Injectable
+ * {@literal @}ConditionalOnProperty("cache.enabled")
+ * public class RedisCacheService implements CacheService { }
+ *
+ * // Fallback implementation (registered only if no CacheService exists)
+ * {@literal @}Injectable
+ * {@literal @}ConditionalOnMissingBean(CacheService.class)
+ * public class InMemoryCacheService implements CacheService { }
+ * </pre>
+ *
+ * <p>The condition is evaluated at registration time. If the specified bean type
+ * is already registered when this bean is being registered, this bean will be skipped.</p>
+ *
+ * @author Abolfazl Azizi
+ * @since 1.0.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConditionalOnMissingBean {
+
+    /**
+     * The bean type(s) that must be absent for this bean to be registered.
+     * If multiple types are specified, ALL must be absent.
+     *
+     * @return the bean type(s) to check
+     */
+    Class<?>[] value();
+}

--- a/src/main/java/io/github/abolpv/lightdi/annotation/ConditionalOnProperty.java
+++ b/src/main/java/io/github/abolpv/lightdi/annotation/ConditionalOnProperty.java
@@ -1,0 +1,74 @@
+package io.github.abolpv.lightdi.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Conditionally registers a bean based on the presence or value of a configuration property.
+ * The bean will only be registered if the specified condition is met.
+ *
+ * <p>Usage examples:</p>
+ *
+ * <p>Register only if property exists:</p>
+ * <pre>
+ * {@literal @}Injectable
+ * {@literal @}ConditionalOnProperty("cache.enabled")
+ * public class RedisCacheService implements CacheService { }
+ * </pre>
+ *
+ * <p>Register only if property has specific value:</p>
+ * <pre>
+ * {@literal @}Injectable
+ * {@literal @}ConditionalOnProperty(value = "cache.type", havingValue = "redis")
+ * public class RedisCacheService implements CacheService { }
+ * </pre>
+ *
+ * <p>Register if property is missing (with matchIfMissing):</p>
+ * <pre>
+ * {@literal @}Injectable
+ * {@literal @}ConditionalOnProperty(value = "cache.enabled", matchIfMissing = true)
+ * public class DefaultCacheService implements CacheService { }
+ * </pre>
+ *
+ * @author Abolfazl Azizi
+ * @since 1.0.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConditionalOnProperty {
+
+    /**
+     * The name of the property to check.
+     * Alias for {@link #name()}.
+     *
+     * @return the property name
+     */
+    String value() default "";
+
+    /**
+     * The name of the property to check.
+     *
+     * @return the property name
+     */
+    String name() default "";
+
+    /**
+     * The expected value of the property.
+     * If not specified, the condition matches if the property exists
+     * and is not equal to "false".
+     *
+     * @return the expected value
+     */
+    String havingValue() default "";
+
+    /**
+     * Whether to match if the property is missing.
+     * If true, the condition matches when the property is not set.
+     * Default is false.
+     *
+     * @return true to match when property is missing
+     */
+    boolean matchIfMissing() default false;
+}


### PR DESCRIPTION
## Summary
Implements conditional bean registration based on properties and other beans, similar to Spring Boot's conditional annotations.

Closes #4

## Changes
- Created `@ConditionalOnProperty` annotation with `value`, `havingValue`, and `matchIfMissing` attributes
- Created `@ConditionalOnBean` annotation to register only when specified beans exist
- Created `@ConditionalOnMissingBean` annotation to register only when specified beans are absent
- Added property management methods to `Container`: `setProperty()`, `getProperty()`, `hasProperty()`
- Updated `ContainerBuilder` with `property()` and `properties()` methods
- Implemented conditional evaluation during bean registration

## Example Usage
```java
// Register only when cache.enabled=true
@Injectable
@ConditionalOnProperty("cache.enabled")
public class RedisCacheService implements CacheService { }

// Register only when no CacheService exists (fallback)
@Injectable
@ConditionalOnMissingBean(CacheService.class)
public class InMemoryCacheService implements CacheService { }

// Register only when UserRepository bean exists
@Injectable
@ConditionalOnBean(UserRepository.class)
public class UserService { }

// Usage with ContainerBuilder
Container container = Container.builder()
    .property("cache.enabled", "true")
    .register(RedisCacheService.class)
    .register(InMemoryCacheService.class)  // Skipped - RedisCacheService exists
    .build();
```

## Test Plan
- [x] `@ConditionalOnProperty` registers when property exists and is not "false"
- [x] `@ConditionalOnProperty` with `havingValue` matches exact value
- [x] `@ConditionalOnProperty` with `matchIfMissing=true` registers when property absent
- [x] `@ConditionalOnBean` registers only when required beans exist
- [x] `@ConditionalOnMissingBean` registers only when beans are absent
- [x] Multiple conditions on same class require all to pass
- [x] ContainerBuilder properly sets properties before registration